### PR TITLE
Chore/upgrade http foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,149 +1,154 @@
 # Changelog
 
--   requires: WordPress 6.0.0
--   tested: WordPress 6.3.1
+- requires: WordPress 6.0.0
+- tested: WordPress 6.3.1
+
+## v1.2.3
+
+- Chore: update symfony/http-foundation
+- Feat: simulate glob() for systems that lack it
 
 ## v1.2.2
 
--   Fix: error messages text
+- Fix: error messages text
 
 ## v1.2.1
 
--   Fix: encrypt fake session id
+- Fix: encrypt fake session id
 
 ## v1.2.0
 
--   Add: improve validation when two IDPs are on the same form and a session is active
--   Chore: update readme and fix badge
+- Add: improve validation when two IDPs are on the same form and a session is active
+- Chore: update readme and fix badge
 
 ## v1.1.9
 
--   Fix: sessionTTL
+- Fix: sessionTTL
 
 ## v1.1.8
 
--   Add: inactivity timer
+- Add: inactivity timer
 
 ## v1.1.7
 
--   Chore: upgrade samlbase dependency due to twig/twig CVE-2022-39261
+- Chore: upgrade samlbase dependency due to twig/twig CVE-2022-39261
 
 ## v1.1.6
 
--   Fix: security warnings on babel/traverse and postcss dependencies
--   Chore: swap teams monologger package
+- Fix: security warnings on babel/traverse and postcss dependencies
+- Chore: swap teams monologger package
 
 ## v1.1.5
 
--   Fix: add CSP only to acs routes.
+- Fix: add CSP only to acs routes.
 
 ## v1.1.4
 
--   Add: CSP to custom routes.
+- Add: CSP to custom routes.
 
 ## v1.1.3
 
--   Chore: add better name for app.js and css to identify plugin.
--   Fix: unsafe eval in webpack and csp inline style.
+- Chore: add better name for app.js and css to identify plugin.
+- Fix: unsafe eval in webpack and csp inline style.
 
 ## v1.1.2
 
--   Change: clean up logging to MS teams.
+- Change: clean up logging to MS teams.
 
 ## v1.1.1
 
--   Change: lazy the session.
--   Fix: PHP tests.
+- Change: lazy the session.
+- Fix: PHP tests.
 
 ## v1.1.0
 
--   Add: make sessions persistent across multiple forms.
+- Add: make sessions persistent across multiple forms.
 
 ## v1.0.19
 
--   Change: use getenv() instead of global $\_ENV.
+- Change: use getenv() instead of global $\_ENV.
 
 ## v1.0.18
 
--   Change: counter + logout button positioning.
+- Change: counter + logout button positioning.
 
 ## v1.0.17
 
--   Fix: counter export default class component.
+- Fix: counter export default class component.
 
 ## v1.0.16
 
--   Change: position of logout button.
+- Change: position of logout button.
 
 ## v1.0.15
 
--   Change: update npm to remove vulnerabilities for lodash & postcss.
+- Change: update npm to remove vulnerabilities for lodash & postcss.
 
 ## v1.0.14
 
 ### Fix
 
--   Fix: trying to access array offset on value of type null (notice).
--   Change: translate English sentence.
--   Change: rewrite namespaces for tests.
+- Fix: trying to access array offset on value of type null (notice).
+- Change: translate English sentence.
+- Change: rewrite namespaces for tests.
 
 ## v1.0.13
 
--   Fix: remove extra quote.
+- Fix: remove extra quote.
 
 ## v1.0.12
 
--   Change: styling and text after login using DigiD.
+- Change: styling and text after login using DigiD.
 
 ## v1.0.11
 
--   Fix: update npm package "ini". This package might have CVE-2020-7788.
+- Fix: update npm package "ini". This package might have CVE-2020-7788.
 
 ## v1.0.10
 
--   Change: update outdated SAML dependency.
+- Change: update outdated SAML dependency.
 
 ## v1.0.9
 
--   Change: better error handling.
+- Change: better error handling.
 
 ## v1.0.8
 
--   Change: set secure and httpOnly cookie.
--   Change: refactor code.
+- Change: set secure and httpOnly cookie.
+- Change: refactor code.
 
 ## v1.0.7
 
--   Change: local storage to session storage.
--   Fix: duration of a resumed session.
+- Change: local storage to session storage.
+- Fix: duration of a resumed session.
 
 ## v1.0.6
 
--   Change: CSS in JS.
+- Change: CSS in JS.
 
 ## v1.0.5
 
 ## v1.0.4
 
--   Change: JS to class instance.
--   Fix: collision with Gravity Forms live validator plugin.
+- Change: JS to class instance.
+- Fix: collision with Gravity Forms live validator plugin.
 
 ## v1.0.3
 
--   Add: extra HTML output for DigiD field.
+- Add: extra HTML output for DigiD field.
 
 ## v1.0.2
 
--   Fix: even better error handling messages.
--   Fix: HTML output for countdown.
+- Fix: even better error handling messages.
+- Fix: HTML output for countdown.
 
 ## v1.0.1
 
--   Add: disabling notifications via .env key `MS_TEAMS_DISABLE_LOGGING=true`.
--   Add: better error handling messages.
--   Fix: refactor views
+- Add: disabling notifications via .env key `MS_TEAMS_DISABLE_LOGGING=true`.
+- Add: better error handling messages.
+- Fix: refactor views
 
 ## v1.0.0
 
--   Add: DigiD login field
--   Add: settings page
+- Add: DigiD login field
+- Add: settings page

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "gogentooss/samlbase": "~1.5",
     "php-di/php-di": "^6.0",
     "aura/session": "^2.1",
-    "symfony/http-foundation": "~5.3",
+    "symfony/http-foundation": "6.3.6",
     "vlucas/phpdotenv": "^5.0",
     "cmdisp/monolog-microsoft-teams": "1.3.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "143439cdd60bf34d9eeba9b189502134",
+    "content-hash": "d06fe1c84d3c114e92a9c96c068e7bbe",
     "packages": [
         {
             "name": "aura/session",
@@ -1464,35 +1464,36 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v5.4.28",
+            "version": "v6.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "365992c83a836dfe635f1e903ccca43ee03d3dd2"
+                "reference": "c186627f52febe09c6d5270b04f8462687a250a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/365992c83a836dfe635f1e903ccca43ee03d3dd2",
-                "reference": "365992c83a836dfe635f1e903ccca43ee03d3dd2",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/c186627f52febe09c6d5270b04f8462687a250a6",
+                "reference": "c186627f52febe09c6d5270b04f8462687a250a6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.1",
-                "symfony/polyfill-php80": "^1.16"
+                "symfony/polyfill-php83": "^1.27"
+            },
+            "conflict": {
+                "symfony/cache": "<6.3"
             },
             "require-dev": {
-                "predis/predis": "~1.0",
-                "symfony/cache": "^4.4|^5.0|^6.0",
+                "doctrine/dbal": "^2.13.1|^3|^4",
+                "predis/predis": "^1.1|^2.0",
+                "symfony/cache": "^6.3",
                 "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/expression-language": "^4.4|^5.0|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
                 "symfony/http-kernel": "^5.4.12|^6.0.12|^6.1.4",
-                "symfony/mime": "^4.4|^5.0|^6.0",
+                "symfony/mime": "^5.4|^6.0",
                 "symfony/rate-limiter": "^5.2|^6.0"
-            },
-            "suggest": {
-                "symfony/mime": "To use the file extension guesser"
             },
             "type": "library",
             "autoload": {
@@ -1520,7 +1521,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v5.4.28"
+                "source": "https://github.com/symfony/http-foundation/tree/v6.3.6"
             },
             "funding": [
                 {
@@ -1536,7 +1537,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-21T07:23:18+00:00"
+            "time": "2023-10-17T11:32:53+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1864,6 +1865,86 @@
                 }
             ],
             "time": "2023-01-26T09:26:14+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php83",
+            "version": "v1.28.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php83.git",
+                "reference": "b0f46ebbeeeda3e9d2faebdfbf4b4eae9b59fa11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/b0f46ebbeeeda3e9d2faebdfbf4b4eae9b59fa11",
+                "reference": "b0f46ebbeeeda3e9d2faebdfbf4b4eae9b59fa11",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "symfony/polyfill-php80": "^1.14"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.28-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php83\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.28.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-08-16T06:22:46+00:00"
         },
         {
             "name": "symfony/service-contracts",

--- a/plugin.php
+++ b/plugin.php
@@ -6,7 +6,7 @@
  * Description: Add a DigiD login field to GravityForms.
  * Author: Yard | Digital Agency
  * Author URI: https://www.yard.nl
- * Version: 1.2.2
+ * Version: 1.2.3
  * License: GPL3.0
  * License URI: https://www.gnu.org/licenses/gpl-3.0.txt
  * Text Domain: owc-gravityforms-digid
@@ -23,7 +23,7 @@ if (! defined('WPINC')) {
 define('GF_DIGID_PLUGIN_FILE', __FILE__);
 define('GF_DIGID_PLUGIN_SLUG', 'owc-gravityforms-digid');
 define('GF_DIGID_ROOT_PATH', __DIR__);
-define('GF_DIGID_VERSION', '1.2.2');
+define('GF_DIGID_VERSION', '1.2.3');
 
 /**
  * Manual loaded file: the autoloader.

--- a/src/DigiD/Foundation/Helpers.php
+++ b/src/DigiD/Foundation/Helpers.php
@@ -156,3 +156,95 @@ function endsWith($haystack, $needles)
 
     return false;
 }
+
+/**
+ * Simulate a `glob()` with the `GLOB_BRACE` flag set. For systems that lack it, e.g. Alpine Linux / Docker.
+ * Copied and adapted from Zend Framework's `Glob::fallbackGlob()` and Glob::nextBraceSub()`.
+ *
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ *
+ * @param string $pattern Filename pattern.
+ * @param void $dummy_flags Not used.
+ *
+ * @return array Array of paths.
+ */
+function globBrace($pattern, $dummyFlags = null) {
+    static $nextBraceSub;
+
+    if (!$nextBraceSub) {
+        // Find the end of the subpattern in a brace expression.
+        $nextBraceSub = function ($pattern, $current) {
+            $length = strlen($pattern);
+            $depth = 0;
+
+            while ($current < $length) {
+                if ('\\' === $pattern[$current]) {
+                    if (++$current === $length) {
+                        break;
+                    }
+                    $current++;
+                } else {
+                    if (('}' === $pattern[$current] && $depth-- === 0) || (',' === $pattern[$current] && 0 === $depth)) {
+                        break;
+                    } elseif ('{' === $pattern[$current++]) {
+                        $depth++;
+                    }
+                }
+            }
+
+            return $current < $length ? $current : null;
+        };
+    }
+
+    $length = strlen($pattern);
+
+    // Find first opening brace.
+    for ($begin = 0; $begin < $length; $begin++) {
+        if ('\\' === $pattern[$begin]) {
+            $begin++;
+        } elseif ('{' === $pattern[$begin]) {
+            break;
+        }
+    }
+
+    // Find comma or matching closing brace.
+    if (null === ($next = $nextBraceSub($pattern, $begin + 1))) {
+        return glob($pattern);
+    }
+
+    $rest = $next;
+
+    // Point `$rest` to matching closing brace.
+    while ('}' !== $pattern[$rest]) {
+        if (null === ($rest = $nextBraceSub($pattern, $rest + 1))) {
+            return glob($pattern);
+        }
+    }
+
+    $paths = array();
+    $p = $begin + 1;
+
+    // For each comma-separated subpattern.
+    do {
+        $subpattern = substr($pattern, 0, $begin)
+            . substr($pattern, $p, $next - $p)
+            . substr($pattern, $rest + 1);
+
+        if (($result = globBrace($subpattern))) {
+            $paths = array_merge($paths, $result);
+        }
+
+        if ('}' === $pattern[$next]) {
+            break;
+        }
+
+        $p = $next + 1;
+        $next = $nextBraceSub($pattern, $p);
+    } while (null !== $next);
+
+    return array_values(array_unique($paths));
+}

--- a/src/DigiD/GravityFormsAddon.php
+++ b/src/DigiD/GravityFormsAddon.php
@@ -196,7 +196,16 @@ class GravityFormsAddon extends GFAddOn
      */
     private function getPublicCertificates(): array
     {
-        return $this->formatListOfCertificates(glob($this->getCertificateLocation() . '/*.{cer}', GLOB_BRACE));
+		$globFunction = 'glob';
+		$flag = 'default';
+
+		if ( ! defined( 'GLOB_BRACE' ) ) {
+			$globFunction = 'Yard\DigiD\Foundation\Helpers\globBrace';
+		} else {
+			$flag = GLOB_BRACE;
+		}
+
+		return $this->formatListOfCertificates($globFunction($this->getCertificateLocation() . '/*.{cer}', $flag));
     }
 
     /**
@@ -230,7 +239,16 @@ class GravityFormsAddon extends GFAddOn
      */
     private function getPrivateCertificates(): array
     {
-        return $this->formatListOfCertificates(glob($this->getCertificateLocation() . '/*.{key}', GLOB_BRACE));
+		$globFunction = 'glob';
+		$flag = 'default';
+
+		if ( ! defined( 'GLOB_BRACE' ) ) {
+			$globFunction = 'Yard\DigiD\Foundation\Helpers\globBrace';
+		} else {
+			$flag = GLOB_BRACE;
+		}
+
+		return $this->formatListOfCertificates($globFunction($this->getCertificateLocation() . '/*.{key}', $flag));
     }
 
     /**


### PR DESCRIPTION
- `symfony/http-foundation` geüpdatet voor Bedrock/Sage
- `GLOB_RACE` check toegevoegd. Als `GLOB_RACE` niet beschikbaar is, wordt de globBrace helper functie gebruikt i.p.v. `glob()`

`GLOB_RACE` is niet beschikbaar voor sommige operating systems, waaronder Alpine Linux, die in Docker containers wordt gebruikt. Afgekeken van `wp-cli` code: https://github.com/wp-cli/wp-cli/pull/4355/files