### PR TITLE
(fix): custom routes being called too early

### DIFF
--- a/src/DigiD/DigiDServiceProvider.php
+++ b/src/DigiD/DigiDServiceProvider.php
@@ -35,7 +35,7 @@ class DigiDServiceProvider extends ServiceProvider
 
         $this->checkSession();
 
-        $this->plugin->getLoader()->addAction('plugins_loaded', $this, 'registerRoutes');
+        $this->plugin->getLoader()->addAction('wp_loaded', $this, 'registerRoutes');
         $this->plugin->getLoader()->addAction('wp_enqueue_scripts', $this, 'loadAssets');
         $this->plugin->getLoader()->addAction('wp_body_open', $this, 'addModalHTML');
         $this->plugin->getLoader()->addFilter('gform_pre_render', $gravityForm, 'clearFormOnFirstRender');


### PR DESCRIPTION
The `plugins_loaded` event fires early before certain other hooks have initialised, replacing this with `wp_loaded` is more suitable as this hook is called just before `parse_request`.