### PR TITLE
fix: ensure bsn is cast to string before encryption

### DIFF
--- a/src/DigiD/DigiDController.php
+++ b/src/DigiD/DigiDController.php
@@ -84,7 +84,7 @@ class DigiDController
         $session->set('status_code', $attributes->status()->get()->getStatusCode());
 
         if ($attributes->status()->get()->isSuccess()) {
-            $session->set('bsn', encrypt($attributes->bsn()->getID()));
+            $session->set('bsn', encrypt((string)$attributes->bsn()->getID()));
             $session->set('nameID', encrypt($attributes->bsn()->getNameID()));
             $session->set('lastActivity', time());
         } else {
@@ -96,7 +96,7 @@ class DigiDController
         $this->logInfo(message: 'Attributes are filled', context: [
             'session_id' => $attributes->sessionID(),
             'status_code' => $attributes->status()->get()->getStatusCode(),
-            'bsn' => encrypt($attributes->bsn()->getID()),
+            'bsn' => encrypt((string)$attributes->bsn()->getID()),
             'nameID' => encrypt($attributes->bsn()->getNameID()),
             'resume_link' => $session->get('resume_link'),
             'message' => $session->get('message'),


### PR DESCRIPTION
Dit gaat fout sinds er hier https://github.com/yardinternet/owc-gravityforms-digid/commit/530123b8c2d7de0520d60417421a99a6b9104935 overal `declare(strict_types=1);` aan is toegevoegd.