### PR TITLE
chore: `multi-gitter-scripts/add-gh-workflow-composer-lock-diff`

### DIFF
--- a/.github/workflows/composer-lock-diff.yml
+++ b/.github/workflows/composer-lock-diff.yml
@@ -1,0 +1,11 @@
+name: Composer Diff
+
+on:
+  pull_request:
+    paths:
+      - 'composer.lock'
+
+jobs:
+  composer-diff:
+    uses: yardinternet/workflows/.github/workflows/composer-lock-diff.yml@main
+    secrets: inherit


### PR DESCRIPTION
- Add github composer-lock-diff.yml if not present in repo
